### PR TITLE
Add user context and isolate storage per user

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import Navigation from './components/Navigation';
 import Dashboard from './components/Dashboard';
 import WorkoutTracker from './components/WorkoutTracker';
@@ -6,8 +6,10 @@ import AthleticTests from './components/AthleticTests';
 import ShootingTracker from './components/ShootingTracker';
 import Analytics from './components/Analytics';
 import AICoach from './components/AICoach';
+import { UserProvider, UserContext } from './context/UserContext';
 
-function App() {
+function AppContent() {
+  const { user, setUser } = useContext(UserContext);
   const [currentTab, setCurrentTab] = useState('dashboard');
 
   const renderCurrentTab = () => {
@@ -26,10 +28,26 @@ function App() {
     <div className="min-h-screen bg-gray-50">
       <Navigation currentTab={currentTab} setCurrentTab={setCurrentTab} />
       <main className="max-w-7xl mx-auto px-4 py-6">
+        <div className="mb-4">
+          <select
+            value={user}
+            onChange={e => setUser(e.target.value as any)}
+            className="p-2 border rounded"
+          >
+            <option value="yassine">Yassine</option>
+            <option value="youssef">Youssef</option>
+          </select>
+        </div>
         {renderCurrentTab()}
       </main>
     </div>
   );
 }
+
+const App = () => (
+  <UserProvider>
+    <AppContent />
+  </UserProvider>
+);
 
 export default App;

--- a/src/components/AICoach.tsx
+++ b/src/components/AICoach.tsx
@@ -1,10 +1,14 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { Brain, Lightbulb, TrendingUp, AlertTriangle, Award } from 'lucide-react';
-import { storage } from '../utils/storage';
+import { createStorage } from '../utils/storage';
+import { UserContext } from '../context/UserContext';
 import { WorkoutSession, AthleticTest, ShootingSession, AIInsight } from '../types';
 import { ATHLETIC_TESTS, WORKOUT_TYPES } from '../utils/constants';
 
 const AICoach: React.FC = () => {
+  const { user } = useContext(UserContext);
+  const storage = createStorage(user);
+
   const [workouts, setWorkouts] = useState<WorkoutSession[]>([]);
   const [athleticTests, setAthleticTests] = useState<AthleticTest[]>([]);
   const [shootingSessions, setShootingSessions] = useState<ShootingSession[]>([]);
@@ -15,7 +19,7 @@ const AICoach: React.FC = () => {
     setAthleticTests(storage.getAthleticTests());
     setShootingSessions(storage.getShootingSessions());
     setInsights(storage.getAIInsights());
-  }, []);
+  }, [user]);
 
   const generateInsights = () => {
     const newInsights: AIInsight[] = [];

--- a/src/components/Analytics.tsx
+++ b/src/components/Analytics.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { BarChart3, TrendingUp, Calendar, Target } from 'lucide-react';
 import { Line, Bar, Doughnut } from 'react-chartjs-2';
 import {
@@ -13,7 +13,8 @@ import {
   Legend,
   ArcElement
 } from 'chart.js';
-import { storage } from '../utils/storage';
+import { createStorage } from '../utils/storage';
+import { UserContext } from '../context/UserContext';
 import { WorkoutSession, AthleticTest, ShootingSession } from '../types';
 import { ATHLETIC_TESTS, SHOOTING_ZONES, WORKOUT_TYPES } from '../utils/constants';
 import { format, subDays, startOfWeek, endOfWeek } from 'date-fns';
@@ -32,6 +33,9 @@ ChartJS.register(
 );
 
 const Analytics: React.FC = () => {
+  const { user } = useContext(UserContext);
+  const storage = createStorage(user);
+
   const [workouts, setWorkouts] = useState<WorkoutSession[]>([]);
   const [athleticTests, setAthleticTests] = useState<AthleticTest[]>([]);
   const [shootingSessions, setShootingSessions] = useState<ShootingSession[]>([]);
@@ -41,7 +45,7 @@ const Analytics: React.FC = () => {
     setWorkouts(storage.getWorkouts());
     setAthleticTests(storage.getAthleticTests());
     setShootingSessions(storage.getShootingSessions());
-  }, []);
+  }, [user]);
 
   const getFilteredData = () => {
     const now = new Date();

--- a/src/components/AthleticTests.tsx
+++ b/src/components/AthleticTests.tsx
@@ -1,10 +1,14 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { Plus, Save, Trash2, Edit, TrendingUp } from 'lucide-react';
-import { storage } from '../utils/storage';
+import { createStorage } from '../utils/storage';
+import { UserContext } from '../context/UserContext';
 import { AthleticTest } from '../types';
 import { ATHLETIC_TESTS } from '../utils/constants';
 
 const AthleticTests: React.FC = () => {
+  const { user } = useContext(UserContext);
+  const storage = createStorage(user);
+
   const [tests, setTests] = useState<AthleticTest[]>([]);
   const [isEditing, setIsEditing] = useState(false);
   const [editingTest, setEditingTest] = useState<AthleticTest | null>(null);
@@ -17,7 +21,7 @@ const AthleticTests: React.FC = () => {
 
   useEffect(() => {
     loadTests();
-  }, []);
+  }, [user]);
 
   const loadTests = () => {
     setTests(storage.getAthleticTests());

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { 
   TrendingUp, 
   Target, 
@@ -8,12 +8,16 @@ import {
   Timer,
   Zap
 } from 'lucide-react';
-import { storage } from '../utils/storage';
+import { createStorage } from '../utils/storage';
+import { UserContext } from '../context/UserContext';
 import { WorkoutSession, AthleticTest, ShootingSession } from '../types';
 import { format, startOfWeek, endOfWeek, isWithinInterval } from 'date-fns';
 import { fr } from 'date-fns/locale';
 
 const Dashboard: React.FC = () => {
+  const { user } = useContext(UserContext);
+  const storage = createStorage(user);
+
   const [workouts, setWorkouts] = useState<WorkoutSession[]>([]);
   const [athleticTests, setAthleticTests] = useState<AthleticTest[]>([]);
   const [shootingSessions, setShootingSessions] = useState<ShootingSession[]>([]);
@@ -22,7 +26,7 @@ const Dashboard: React.FC = () => {
     setWorkouts(storage.getWorkouts());
     setAthleticTests(storage.getAthleticTests());
     setShootingSessions(storage.getShootingSessions());
-  }, []);
+  }, [user]);
 
   const getWeeklyStats = () => {
     const now = new Date();

--- a/src/components/ShootingTracker.tsx
+++ b/src/components/ShootingTracker.tsx
@@ -1,10 +1,14 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { Save, Trash2, Edit, Target, Plus, X, BarChart2 } from 'lucide-react';
-import { storage } from '../utils/storage';
+import { createStorage } from '../utils/storage';
+import { UserContext } from '../context/UserContext';
 import { ShootingSession, ShootingZone } from '../types';
 import { SHOOTING_ZONES } from '../utils/constants';
 
 const ShootingTracker: React.FC = () => {
+  const { user } = useContext(UserContext);
+  const storage = createStorage(user);
+
   const [sessions, setSessions] = useState<ShootingSession[]>([]);
   const [currentSession, setCurrentSession] = useState<ShootingZone[]>(
     SHOOTING_ZONES.map(zone => ({ zone: zone.id, attempts: 0, makes: 0, percentage: 0 }))
@@ -16,7 +20,7 @@ const ShootingTracker: React.FC = () => {
 
   useEffect(() => {
     loadSessions();
-  }, []);
+  }, [user]);
 
   const loadSessions = () => {
     setSessions(storage.getShootingSessions());

--- a/src/components/WorkoutTracker.tsx
+++ b/src/components/WorkoutTracker.tsx
@@ -1,10 +1,14 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { Plus, Save, Trash2, Edit } from 'lucide-react';
-import { storage } from '../utils/storage';
+import { createStorage } from '../utils/storage';
+import { UserContext } from '../context/UserContext';
 import { WorkoutSession, Exercise } from '../types';
 import { WORKOUT_TYPES } from '../utils/constants';
 
 const WorkoutTracker: React.FC = () => {
+  const { user } = useContext(UserContext);
+  const storage = createStorage(user);
+
   const [workouts, setWorkouts] = useState<WorkoutSession[]>([]);
   const [isEditing, setIsEditing] = useState(false);
   const [editingWorkout, setEditingWorkout] = useState<WorkoutSession | null>(null);
@@ -18,7 +22,7 @@ const WorkoutTracker: React.FC = () => {
 
   useEffect(() => {
     loadWorkouts();
-  }, []);
+  }, [user]);
 
   const loadWorkouts = () => {
     setWorkouts(storage.getWorkouts());

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -1,0 +1,32 @@
+import React, { createContext, useState, useEffect } from 'react';
+
+export type User = 'yassine' | 'youssef';
+
+interface UserContextType {
+  user: User;
+  setUser: (user: User) => void;
+}
+
+export const UserContext = createContext<UserContextType>({
+  user: 'yassine',
+  setUser: () => {}
+});
+
+const USER_KEY = 'fitness_tracker_user';
+
+export const UserProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [user, setUserState] = useState<User>(() => {
+    const stored = localStorage.getItem(USER_KEY);
+    return (stored as User) || 'yassine';
+  });
+
+  useEffect(() => {
+    localStorage.setItem(USER_KEY, user);
+  }, [user]);
+
+  return (
+    <UserContext.Provider value={{ user, setUser: setUserState }}>
+      {children}
+    </UserContext.Provider>
+  );
+};

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,98 +1,108 @@
 import { WorkoutSession, AthleticTest, ShootingSession, AIInsight } from '../types';
 
-const STORAGE_KEYS = {
-  WORKOUTS: 'fitness_tracker_workouts',
-  ATHLETIC_TESTS: 'fitness_tracker_athletic_tests',
-  SHOOTING_SESSIONS: 'fitness_tracker_shooting_sessions',
-  AI_INSIGHTS: 'fitness_tracker_ai_insights'
-};
+const getKeys = (user: string) => ({
+  WORKOUTS: `fitness_tracker_${user}_workouts`,
+  ATHLETIC_TESTS: `fitness_tracker_${user}_athletic_tests`,
+  SHOOTING_SESSIONS: `fitness_tracker_${user}_shooting_sessions`,
+  AI_INSIGHTS: `fitness_tracker_${user}_ai_insights`
+});
 
-export const storage = {
-  // Workouts
-  saveWorkout: (workout: WorkoutSession) => {
-    const workouts = storage.getWorkouts();
+export const createStorage = (user: string) => {
+  const STORAGE_KEYS = getKeys(user);
+
+  const getWorkouts = (): WorkoutSession[] => {
+    const data = localStorage.getItem(STORAGE_KEYS.WORKOUTS);
+    return data ? JSON.parse(data) : [];
+  };
+
+  const saveWorkout = (workout: WorkoutSession) => {
+    const workouts = getWorkouts();
     const existingIndex = workouts.findIndex(w => w.id === workout.id);
-    
     if (existingIndex >= 0) {
       workouts[existingIndex] = workout;
     } else {
       workouts.push(workout);
     }
-    
     localStorage.setItem(STORAGE_KEYS.WORKOUTS, JSON.stringify(workouts));
-  },
+  };
 
-  getWorkouts: (): WorkoutSession[] => {
-    const data = localStorage.getItem(STORAGE_KEYS.WORKOUTS);
+  const deleteWorkout = (id: string) => {
+    const workouts = getWorkouts().filter(w => w.id !== id);
+    localStorage.setItem(STORAGE_KEYS.WORKOUTS, JSON.stringify(workouts));
+  };
+
+  const getAthleticTests = (): AthleticTest[] => {
+    const data = localStorage.getItem(STORAGE_KEYS.ATHLETIC_TESTS);
     return data ? JSON.parse(data) : [];
-  },
+  };
 
-  deleteWorkout: (id: string) => {
-    const workouts = storage.getWorkouts().filter(w => w.id !== id);
-    localStorage.setItem(STORAGE_KEYS.WORKOUTS, JSON.stringify(workouts));
-  },
-
-  // Athletic Tests
-  saveAthleticTest: (test: AthleticTest) => {
-    const tests = storage.getAthleticTests();
+  const saveAthleticTest = (test: AthleticTest) => {
+    const tests = getAthleticTests();
     const existingIndex = tests.findIndex(t => t.id === test.id);
-    
     if (existingIndex >= 0) {
       tests[existingIndex] = test;
     } else {
       tests.push(test);
     }
-    
     localStorage.setItem(STORAGE_KEYS.ATHLETIC_TESTS, JSON.stringify(tests));
-  },
+  };
 
-  getAthleticTests: (): AthleticTest[] => {
-    const data = localStorage.getItem(STORAGE_KEYS.ATHLETIC_TESTS);
+  const deleteAthleticTest = (id: string) => {
+    const tests = getAthleticTests().filter(t => t.id !== id);
+    localStorage.setItem(STORAGE_KEYS.ATHLETIC_TESTS, JSON.stringify(tests));
+  };
+
+  const getShootingSessions = (): ShootingSession[] => {
+    const data = localStorage.getItem(STORAGE_KEYS.SHOOTING_SESSIONS);
     return data ? JSON.parse(data) : [];
-  },
+  };
 
-  deleteAthleticTest: (id: string) => {
-    const tests = storage.getAthleticTests().filter(t => t.id !== id);
-    localStorage.setItem(STORAGE_KEYS.ATHLETIC_TESTS, JSON.stringify(tests));
-  },
-
-  // Shooting Sessions
-  saveShootingSession: (session: ShootingSession) => {
-    const sessions = storage.getShootingSessions();
+  const saveShootingSession = (session: ShootingSession) => {
+    const sessions = getShootingSessions();
     const existingIndex = sessions.findIndex(s => s.id === session.id);
-    
     if (existingIndex >= 0) {
       sessions[existingIndex] = session;
     } else {
       sessions.push(session);
     }
-    
     localStorage.setItem(STORAGE_KEYS.SHOOTING_SESSIONS, JSON.stringify(sessions));
-  },
+  };
 
-  getShootingSessions: (): ShootingSession[] => {
-    const data = localStorage.getItem(STORAGE_KEYS.SHOOTING_SESSIONS);
-    return data ? JSON.parse(data) : [];
-  },
-
-  deleteShootingSession: (id: string) => {
-    const sessions = storage.getShootingSessions().filter(s => s.id !== id);
+  const deleteShootingSession = (id: string) => {
+    const sessions = getShootingSessions().filter(s => s.id !== id);
     localStorage.setItem(STORAGE_KEYS.SHOOTING_SESSIONS, JSON.stringify(sessions));
-  },
+  };
 
-  // AI Insights
-  saveAIInsight: (insight: AIInsight) => {
-    const insights = storage.getAIInsights();
-    insights.push(insight);
-    localStorage.setItem(STORAGE_KEYS.AI_INSIGHTS, JSON.stringify(insights));
-  },
-
-  getAIInsights: (): AIInsight[] => {
+  const getAIInsights = (): AIInsight[] => {
     const data = localStorage.getItem(STORAGE_KEYS.AI_INSIGHTS);
     return data ? JSON.parse(data) : [];
-  },
+  };
 
-  clearAIInsights: () => {
+  const saveAIInsight = (insight: AIInsight) => {
+    const insights = getAIInsights();
+    insights.push(insight);
+    localStorage.setItem(STORAGE_KEYS.AI_INSIGHTS, JSON.stringify(insights));
+  };
+
+  const clearAIInsights = () => {
     localStorage.setItem(STORAGE_KEYS.AI_INSIGHTS, JSON.stringify([]));
-  }
+  };
+
+  return {
+    saveWorkout,
+    getWorkouts,
+    deleteWorkout,
+    saveAthleticTest,
+    getAthleticTests,
+    deleteAthleticTest,
+    saveShootingSession,
+    getShootingSessions,
+    deleteShootingSession,
+    saveAIInsight,
+    getAIInsights,
+    clearAIInsights
+  };
 };
+
+// Default storage for backward compatibility
+export const storage = createStorage('default');


### PR DESCRIPTION
## Summary
- add `UserProvider` context to manage current user
- update `App` to wrap everything with provider and add a selector
- adjust storage helpers to create keys scoped by user
- refactor major components to load/save data using the selected user

## Testing
- `npx tsc -p tsconfig.json`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6876438561cc8325afb286825eae3c3d